### PR TITLE
chore: remove aws-portal action since it will be depracated

### DIFF
--- a/templates/iam/policy_1.json
+++ b/templates/iam/policy_1.json
@@ -72,7 +72,6 @@
                 "aws-marketplace:List*",
                 "aws-marketplace:MeterUsage",
                 "aws-marketplace:View*",
-                "aws-portal:View*",
                 "awsconnector:Get*",
                 "backup-gateway:List*",
                 "backup:Describe*",


### PR DESCRIPTION
Launch update: Until July 6, 2023, you can switch between using the new fine-grained IAM actions and the old IAM actions with the newly launched feature. It helps you experiment with the new IAM actions to ensure your intended permissions are in place. It also allows you to plan your own migration, if you decide to complete sooner than July 6, 2023, or extend the support of existing IAM actions till July 6, 2023 for accounts or organizations created after March 6, 2023. See details in [“How to toggle accounts between new fine-grained actions or existing IAM Actions?”](https://aws.amazon.com/blogs/aws-cloud-financial-management/changes-to-aws-billing-cost-management-and-account-consoles-permissions/#How-to-toggle-accounts-between-new-fine-grained-actions-or-existing-IAM-Actions)

https://aws.amazon.com/blogs/aws-cloud-financial-management/changes-to-aws-billing-cost-management-and-account-consoles-permissions/

Closes #1 